### PR TITLE
fix build on gcc-10 (-fno-common)

### DIFF
--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -36,7 +36,7 @@ extern bool debug_mode;
 
 /* The current position in the input buffer. Useful to determine if any
  * characters of the password have already been entered or not. */
-int input_position;
+extern int input_position;
 
 /* The lock window. */
 extern xcb_window_t win;


### PR DESCRIPTION
gcc-10 changed the default from -fcommon to fno-common:
  https://gcc.gnu.org/PR85678

As a result build fails as:

    ld: i3lock-unlock_indicator.o:(.bss+0xc): multiple definition of
      `input_position'; i3lock-i3lock.o:(.bss+0x3c): first defined here

The change turned one of definitions into declaration.